### PR TITLE
Updated dependencies. Suppressed a needless warning.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ A simple log implementation that logs to stdout and stderr with colors
 
 [dependencies]
 log = "0.3.5"
-ansi_term = "0.7.2"
+ansi_term = "0.9"
 
 [[example]]
 name = "clap"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ impl Log for VLogger {
         metadata.level() <= self.log_level
     }
 
+    #[allow(unused_must_use)]
     fn log(&self, record: &LogRecord) {
         if self.enabled(record.metadata()) {
             let msg = format!("{}: {}",


### PR DESCRIPTION
The dependency updates are functionally the same, this is just to reduce the amount of older dependencies. Should be only a minor version bump since none of these dependencies are public.

Suppressed a warning with the `writeln!` macro.