### PR TITLE
Log to stdout/stderr without allocating

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,13 +106,12 @@ impl Log for VLogger {
 
     fn log(&self, record: &LogRecord) {
         if self.enabled(record.metadata()) {
-            let msg = format!("{}: {}",
-                              level_style(record.level()).paint(record.location().module_path()),
-                              record.args());
+            let level = level_style(record.level()).paint(record.location().module_path());
+
             if record.level() <= LogLevel::Warn {
-                let _ = writeln!(&mut io::stderr(), "{}", msg);
+                let _ = writeln!(&mut io::stderr(), "{}: {}", level, record.args());
             } else {
-                println!("{}", msg);
+                println!("{}: {}", level, record.args());
             }
         }
     }


### PR DESCRIPTION
Hi!

Hope this works here. Found this crate via some recent blog posts, and thought I'd see if I could help at all.

This commit removes the allocation of an intermediate `String` in `log`, so the log path is now allocation-free. This is likely a premature optimization, but it's a small change for much faster logging - and not allocation when not needed is a plus, in my mind.