### PR TITLE
Disable ansi color when either stdout or stderr isn't a tty

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/clux/loggerv"
 version = "0.3.0"
 
 [dependencies]
+atty = "0.2.2"
 ansi_term = "0.9.0"
 log = "0.3.7"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ extern crate log;
 #[cfg(not(test))]
 extern crate log;
 
+extern crate atty;
 extern crate ansi_term;
 
 use log::{Log, LogLevel, LogMetadata, LogRecord, SetLoggerError};
@@ -106,7 +107,12 @@ impl Log for VLogger {
 
     fn log(&self, record: &LogRecord) {
         if self.enabled(record.metadata()) {
-            let level = level_style(record.level()).paint(record.location().module_path());
+            let level = if atty::is(atty::Stream::Stdout) && atty::is(atty::Stream::Stderr) {
+                format!("{}",
+                        level_style(record.level()).paint(record.location().module_path()))
+            } else {
+                format!("{}", record.location().module_path())
+            };
 
             if record.level() <= LogLevel::Warn {
                 let _ = writeln!(&mut io::stderr(), "{}: {}", level, record.args());


### PR DESCRIPTION
One of the benefits of logging is dumping the output to a text file
for later review.

This change modifies loggerv so that it only prints ansi codes
when stdout and stderr are both connect to a controlling terminal.
On the other hand, when either is being redirected, color is disabled.

Ideally color would be disabled for stdout and stderr separately, but
this change is small, to the point, and takes it 90% of the way to where
it wants to be.