### PR TITLE
Add `base_level` functionality

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,6 +229,24 @@ impl Logger {
     /// If the level, line numbers, and module path are all _not_ included in the log statement,
     /// then the separator is changed to the empty string to avoid printing a lone string or
     /// character before each message portion of the log statement.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// #[macro_use] extern crate log;
+    /// extern crate loggerv;
+    ///
+    /// use log::LogLevel;
+    ///
+    /// fn main() {
+    ///     loggerv::Logger::new()
+    ///         .separator(" = ")
+    ///         .init()
+    ///         .unwrap();
+    ///
+    ///     error!("This is printed with an equal sign between the module path and this message");
+    /// }
+    /// ```
     pub fn separator(mut self, s: &str) -> Self {
         self.separator = String::from(s);
         self
@@ -238,6 +256,24 @@ impl Logger {
     ///
     /// If the logger is _not_ used in a terminal, then the output is _not_ colorized regardless of
     /// this value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// #[macro_use] extern crate log;
+    /// extern crate loggerv;
+    ///
+    /// use log::LogLevel;
+    ///
+    /// fn main() {
+    ///     loggerv::Logger::new()
+    ///         .colors(false)
+    ///         .init()
+    ///         .unwrap();
+    ///
+    ///     error!("This is printed without any colorization");
+    /// }
+    /// ```
     pub fn colors(mut self, c: bool) -> Self {
         self.colors = c && atty::is(atty::Stream::Stdout) && atty::is(atty::Stream::Stderr);
         self
@@ -247,13 +283,51 @@ impl Logger {
     ///
     /// The default is to colorize the output unless `stdout` and `stderr` are redirected or piped,
     /// i.e. not a tty.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// #[macro_use] extern crate log;
+    /// extern crate loggerv;
+    ///
+    /// use log::LogLevel;
+    ///
+    /// fn main() {
+    ///     loggerv::Logger::new()
+    ///         .no_colors()
+    ///         .init()
+    ///         .unwrap();
+    ///
+    ///     error!("This is printed without any colorization");
+    /// }
+    /// ```
     pub fn no_colors(mut self) -> Self {
         self. colors = false;
         self
     }
 
-    /// Enables or disables including line numbers in the "tag" portion of the log statement. The
-    /// tag is the text to the left of the separator.
+    /// Enables or disables including line numbers in the "tag" portion of the log statement. 
+    ///
+    /// The tag is the text to the left of the separator.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// #[macro_use] extern crate log;
+    /// extern crate loggerv;
+    ///
+    /// use log::LogLevel;
+    ///
+    /// fn main() {
+    ///     loggerv::Logger::new()
+    ///         .line_numbers(true)
+    ///         .init()
+    ///         .unwrap();
+    ///
+    ///     error!("This is printed with the module path and the line number surrounded by
+    ///     parentheses");
+    /// }
+    /// ```
     pub fn line_numbers(mut self, i: bool) -> Self {
         self.include_line_numbers = i;
         self
@@ -264,12 +338,53 @@ impl Logger {
     ///
     /// If the level and the module path are both inculded, then the module path is surrounded by
     /// square brackets.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// #[macro_use] extern crate log;
+    /// extern crate loggerv;
+    ///
+    /// use log::LogLevel;
+    ///
+    /// fn main() {
+    ///     loggerv::Logger::new()
+    ///         .level(true)
+    ///         .init()
+    ///         .unwrap();
+    ///
+    ///     error!("This is printed with the 'ERROR' and the module path is surrounded in square
+    ///     brackets");
+    /// }
+    /// ```
     pub fn level(mut self, i: bool) -> Self {
         self.include_level = i;
         self
     }
 
     /// Explicitly sets the log level instead of through a verbosity.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// #[macro_use] extern crate log;
+    /// extern crate loggerv;
+    ///
+    /// use log::LogLevel;
+    ///
+    /// fn main() {
+    ///     loggerv::Logger::new()
+    ///         .max_level(LogLevel::Info)
+    ///         .init()
+    ///         .unwrap();
+    ///
+    ///     error!("This is printed to stderr");
+    ///     warn!("This is printed to stderr");
+    ///     info!("This is printed to stdout");
+    ///     debug!("This is not printed to stdout");
+    ///     trace!("This is not printed to stdout");
+    /// }
+    /// ```
     pub fn max_level(mut self, l: LogLevel) -> Self {
         self.level = l;
         // It is important to set the Verbosity to None here because later with the `init` method,
@@ -284,6 +399,22 @@ impl Logger {
     ///
     /// The tag is the text to the left of the separator. The default is to include the module
     /// path. Ifthe level is also included, the module path is surrounded by square brackets.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// #[macro_use] extern crate log;
+    /// extern crate loggerv;
+    ///
+    /// fn main() {
+    ///     loggerv::Logger::new()
+    ///         .module_path(false)
+    ///         .init()
+    ///         .unwrap();
+    ///
+    ///     error!("This is printed without leading module path and separator");
+    /// }
+    /// ```
     pub fn module_path(mut self, i: bool) -> Self {
         self.include_module_path = i;
         self
@@ -293,6 +424,22 @@ impl Logger {
     ///
     /// The tag is the text to the left of the separator. The default is to include the module
     /// path.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// #[macro_use] extern crate log;
+    /// extern crate loggerv;
+    ///
+    /// fn main() {
+    ///     loggerv::Logger::new()
+    ///         .no_module_path()
+    ///         .init()
+    ///         .unwrap();
+    ///
+    ///     error!("This is printed without leading module path and separator");
+    /// }
+    /// ```
     pub fn no_module_path(mut self) -> Self {
         self.include_module_path = false;
         self
@@ -364,10 +511,29 @@ impl Logger {
     /// A verbosity of zero (0) is the default, which means ERROR and WARN log statements are
     /// printed to `stderr`. No other log statements are printed on any of the standard streams
     /// (`stdout` or `stderr`). As the verbosity is increased, the log level is increased and more
-    /// log statements will be printed to `stdout`. A verbosity of 1 will print INFO log statements
-    /// to `stdout` in addition to ERROR and WARN. A verbosity of 2 will print INFO and DEBUG log
-    /// statements to `stdout`. A verbosity of 3 or higher will print INFO, DEBUG, and TRACE
-    /// log statements to `stdout` with ERROR and WARN statements printed to `stderr`.
+    /// log statements will be printed to `stdout`. 
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// #[macro_use] extern crate log;
+    /// extern crate loggerv;
+    ///
+    /// use log::LogLevel;
+    ///
+    /// fn main() {
+    ///     loggerv::Logger::new()
+    ///         .verbosity(1)
+    ///         .init()
+    ///         .unwrap();
+    ///
+    ///     error!("This is printed to stderr");
+    ///     warn!("This is printed to stderr");
+    ///     info!("This is printed to stdout");
+    ///     debug!("This is not printed to stdout");
+    ///     trace!("This is not printed to stdout");
+    /// }
+    /// ```
     pub fn verbosity(mut self, v: u64) -> Self {
         self.verbosity = Some(v);
         self
@@ -377,9 +543,55 @@ impl Logger {
     ///
     /// This also consumes the logger. It cannot be further modified after initialization. 
     ///
+    /// # Example
+    ///
+    /// ```rust
+    /// #[macro_use] extern crate log;
+    /// extern crate loggerv;
+    ///
+    /// use log::LogLevel;
+    ///
+    /// fn main() {
+    ///     loggerv::Logger::new()
+    ///         .init()
+    ///         .unwrap();
+    ///
+    ///     error!("This is printed to stderr");
+    ///     warn!("This is printed to stderr");
+    ///     info!("This is not printed to stdout");
+    ///     debug!("This is not printed to stdout");
+    ///     trace!("This is not printed to stdout");
+    /// }
+    /// ```
+    ///
+    /// # Example
+    ///
     /// If the tag will be empty because the level, line numbers, and module path were all
     /// disabled, then the separator is changed to the empty string to avoid writing a long
     /// character in front of each message for each log statement.
+    ///
+    ///
+    /// ```rust
+    /// #[macro_use] extern crate log;
+    /// extern crate loggerv;
+    ///
+    /// use log::LogLevel;
+    ///
+    /// fn main() {
+    ///     loggerv::Logger::new()
+    ///         .module_path(false)
+    ///         .level(false) 
+    ///         .line_numbers(false)
+    ///         .init()
+    ///         .unwrap();
+    ///
+    ///     error!("This is printed to stderr without the separator");
+    ///     warn!("This is printed to stderr without the separator");
+    ///     info!("This is not printed to stdout");
+    ///     debug!("This is not printed to stdout");
+    ///     trace!("This is not printed to stdout");
+    /// }
+    /// ```
     pub fn init(mut self) -> Result<(), SetLoggerError> {
         // If there is no level, line number, or module path in the tag, then the tag will always
         // be empty. The separator should also be empty so only the message component is printed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,9 +298,23 @@ impl Logger {
         self
     }
 
-    /// Sets the offset between the base level and verbosity.
-    pub fn offset(mut self, o: u64) -> Self {
-        self.offset = o;
+    /// Sets the base level.
+    ///
+    /// The base level is the level used with zero (0) verbosity. The default is WARN. So, ERROR
+    /// and WARN statements will be written and INFO statements will be written with a verbosity of
+    /// 1 or greater. If the base level was changed to ERROR, then only ERROR statements will be
+    /// written and WARN statements will be written with a verbosity of 1 or greater. Use this
+    /// adjust the correlation of verbosity, i.e. number of `-v` occurrences, to level.
+    // TODO: Add documentation example to better example
+    pub fn base_level(mut self, b: LogLevel) -> Self {
+        self.offset = match b {
+            LogLevel::Error => 0,
+            LogLevel::Warn => 1,
+            LogLevel::Info => 2,
+            LogLevel::Debug => 3,
+            LogLevel::Trace => 4,
+                
+        };
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -609,10 +609,10 @@ impl Logger {
         // `max_level` method is used, then the `DEFAULT_LEVEL` is used because it is set with the
         // `new` function. It makes more sense to calculate the level based on verbosity _after_
         // all configuration methods have been called as opposed to during the call to the
-        // `verbosity` method. This change enables the offset feature so that the `offset` method
-        // can be used at any time during the "building" procedure before the call to `init`.
-        // Otherwise, calling the `offset` _after_ the `verbosity` method would have no effect and
-        // be difficult to communicate this limitation to users.
+        // `verbosity` method. This change enables the offset feature so that the `max_level`
+        // method can be used at any time during the "building" procedure before the call to
+        // `init`. Otherwise, calling the `max_level` _after_ the `verbosity` method would have no
+        // effect and be difficult to communicate this limitation to users.
         if let Some(v) = self.verbosity {
             self.level = match v + self.offset {
                 0 => LogLevel::Error,  

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,29 +309,43 @@ impl Logger {
     /// # Example
     ///
     /// ```rust
-    /// loggerv::Logger::new()
-    ///     .base_level(LogLevel::Error)
-    ///     .verbosity(0)
-    ///     .init()
-    ///     .unwarp();
+    /// #[macro_use] extern crate log;
+    /// extern crate loggerv;
     ///
-    /// error!("This is printed");
-    /// warn!("This is not printed");
-    /// info!("This is not printed");
+    /// use log::LogLevel;
+    ///
+    /// fn main() {
+    ///     loggerv::Logger::new()
+    ///         .base_level(LogLevel::Error)
+    ///         .verbosity(0)
+    ///         .init()
+    ///         .unwrap();
+    ///
+    ///     error!("This is printed");
+    ///     warn!("This is not printed");
+    ///     info!("This is not printed");
+    /// }
     /// ```
     ///
     /// # Example
     ///
     /// ```rust
-    /// loggerv::Logger::new()
-    ///     .base_level(LogLevel::Info)
-    ///     .verbosity(0)
-    ///     .init()
-    ///     .unwrap();
+    /// #[macro_use] extern crate log;
+    /// extern crate loggerv;
+    /// 
+    /// use log::LogLevel;
     ///
-    /// error!("This is printed")
-    /// warn!("This is also printed")
-    /// info!("This is now printed, too")
+    /// fn main() {
+    ///     loggerv::Logger::new()
+    ///         .base_level(LogLevel::Info)
+    ///         .verbosity(0)
+    ///         .init()
+    ///         .unwrap();
+    ///
+    ///     error!("This is printed");
+    ///     warn!("This is also printed");
+    ///     info!("This is now printed, too");
+    /// }
     /// ```
     pub fn base_level(mut self, b: LogLevel) -> Self {
         self.offset = match b {
@@ -588,6 +602,13 @@ mod tests {
     fn max_level_works() {
         let logger = Logger::new().max_level(LogLevel::Trace);
         assert_eq!(logger.level, LogLevel::Trace);
+        assert!(logger.verbosity.is_none());
+    }
+
+    #[test]
+    fn base_level_works() {
+        let logger = Logger::new().base_level(LogLevel::Info);
+        assert_eq!(logger.offset, 2);
     }
 
     #[test]
@@ -605,7 +626,7 @@ mod tests {
     #[test]
     fn verbosity_works() {
         let logger = Logger::new().verbosity(3);
-        assert_eq!(logger.level, LogLevel::Trace);
+        assert_eq!(logger.verbosity, Some(3));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,34 @@ impl Logger {
     /// 1 or greater. If the base level was changed to ERROR, then only ERROR statements will be
     /// written and WARN statements will be written with a verbosity of 1 or greater. Use this
     /// adjust the correlation of verbosity, i.e. number of `-v` occurrences, to level.
-    // TODO: Add documentation example to better example
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// loggerv::Logger::new()
+    ///     .base_level(LogLevel::Error)
+    ///     .verbosity(0)
+    ///     .init()
+    ///     .unwarp();
+    ///
+    /// error!("This is printed");
+    /// warn!("This is not printed");
+    /// info!("This is not printed");
+    /// ```
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// loggerv::Logger::new()
+    ///     .base_level(LogLevel::Info)
+    ///     .verbosity(0)
+    ///     .init()
+    ///     .unwrap();
+    ///
+    /// error!("This is printed")
+    /// warn!("This is also printed")
+    /// info!("This is now printed, too")
+    /// ```
     pub fn base_level(mut self, b: LogLevel) -> Self {
         self.offset = match b {
             LogLevel::Error => 0,


### PR DESCRIPTION
This pull request implements a `base_level` method for changing the level that is printed when the verbosity is zero (0). It also adds examples to almost all methods and alphabetizes the constants.

The `base_level` is the level that is printed when the verbosity is zero (0). With all defaults, this is the WARN level and it was "hard-coded" into the crate. I can foresee situations where a developer may want to deviate from this behavior. 

For example, a developer may want to have WARN statements only displayed after the first occurrence of the `-v` flag, so ERROR statements would only be displayed when the verbosity is zero. Warnings could add "noise" to the output in some CLI applications and contexts, such as "support" mode discussed in #6 , but useful in development and debugging. Another situation would be to also want the INFO statements displayed without needing to set a verbosity flag at the command line. 

I will admit both of these examples are edge cases and I like having errors and warnings displayed by default, but a developer would currently have to fork/clone this crate and modify the source to obtain a different level when the verbosity is zero.

As I was developing the `base_level` method, it became difficult to explain its purpose without examples. So, I added an example to the method documentation for `base_level`. Then it looked funny to have only method documentation examples for `base_level` and not the other methods. Thus, I added the examples to the other methods as well.

I wanted to share and discuss if needed before just merging the feature.