### PR TITLE
Refactor color method and add output method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,7 +538,7 @@ impl Logger {
     /// Sets the output for a level.
     ///
     /// The output is either `stderr` or `stdout`. The default is for ERROR and WARN to be written
-    /// to `stdout` and INFO, DEBUG, and TRACE to stdout.
+    /// to `stderr` and INFO, DEBUG, and TRACE to `stdout`.
     ///
     /// # Example
     ///


### PR DESCRIPTION
I was not a huge fan of my original implementation of configuring the color on a per-level basis with the `error_color`, `warn_color`, etc. methods. I think having a `*_color` method for each level added too many, too similar methods to the API. What if other per-level configurations were added? Would there need to be `error_*`, `warn_*, etc. methods for each level? This would greatly expand the API and eventually be overwhelming. So, I experimented with refactoring the `*_color` methods, and this pull request is what I came up with. 

Changing the `*_color` methods to a single `color(self, l: LogLevel, c: Colour)` method feels more appropriate. There could be some confusion with the `colors` method (plural), which enables/disables all colors, but this kind of makes sense to me.

Changing the `*_color` methods also required some refactoring of the internal structure, which lead to being able to implement an `output` method with a similar signature to the new `color` method, but it allows the output stream for each level to be changed from the default, where ERROR and WARN are written to `stderr` and INFO, DEBUG, and TRACE are written to `stdout`. I will say I like the default configuration and it is a common convention in other environments as noted in the comments in #5.

But, I do see situations where it would be nice to have all log statements on `stderr`. For example, if I am piping `stdin` and `stdout` into and out of my application, then I would still want to see the log statements from my application. I believe a similar situation was the origin of #5. The `output` method and its implementation would allow for an all `stderr` output as follows:

```rust
loggerv::Logger
    .output(LogLevel::Info, Output::Stderr)
    .output(LogLevel::Debug, Output::Stderr)
    .output(LogLevel::Trace, Output::Stderr)
    .init();
```

The `stderr` would be an alternative user-facing console output that could be helpful for debugging a string of piped applications. A CLI argument could be added with [clap](https://crates.io/crates/clap) or similar to toggle output. It would also be kind of cool to automatically have log statements all go to `stderr` if my application's `stdout` is being piped into another application or file. The [atty](https://crates.io/crates/atty) crate would be used to make this happen, but this would be a per-application/project implementation, not something this crate would need to implement, just enable with the `output` method.

Thoughts?