### PR TITLE
Add example and fix typos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["log", "logger", "stdio", "cli"]
 license = "MIT"
 name = "loggerv"
 repository = "https://github.com/clux/loggerv"
-version = "0.5.1"
+version = "0.6.0"
 readme = "README.md"
 
 [dependencies]
@@ -33,4 +33,8 @@ path = "examples/compile_time_config.rs"
 [[example]]
 name = "cfg-config"
 path = "examples/cfg_config.rs"
+
+[[example]]
+name = "output-config"
+path = "examples/output_config.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ authors = ["Eirik Albrigtsen <sszynrae@gmail.com>",
 description = "A simple log implementation that logs to stdout and stderr with colors"
 documentation = "http://clux.github.io/loggerv"
 keywords = ["log", "logger", "stdio", "cli"]
+categories = ["command-line-utilties"]
 license = "MIT"
 name = "loggerv"
 repository = "https://github.com/clux/loggerv"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ First, add this to your `Cargo.toml`:
 ```toml
 [dependencies]
 log = "0.3"
-loggerv = "0.5"
+loggerv = "0.6"
 ```
 
 Next, add this to the `main.rs` or the file containing the `main` function for your CLI program:

--- a/examples/cfg_config.rs
+++ b/examples/cfg_config.rs
@@ -4,8 +4,8 @@
 //! The default output is `module::path: message`, and the "tag", which is the text to the left of
 //! the colon, is colorized. This example shows how to change the output based on a conditional
 //! compilation, such as a Debug versus Release build. In a Debug build, the default output is
-//! used with a maximum level of Trace. In a Release build, the module path is replaced with the
-//! level and the maximum level is limited to Info.
+//! used with a maximum level of TRACE. In a Release build, the module path is replaced with the
+//! level and the maximum level is limited to INFO.
 //!
 //! The [clap](https://crates.io/crates/clap) argument parser is used in this example, but loggerv
 //! works with any argument parser.

--- a/examples/output_config.rs
+++ b/examples/output_config.rs
@@ -1,0 +1,57 @@
+//! An example using the Builder pattern API to configure the logger at run-time to change
+//! the output stream for the INFO, DEBUG, and TRACE levels from `stdout` to `stderr`.
+//!
+//! The default output stream for INFO, DEBUG, and TRACE levels is `stdout`. This example
+//! demonstrates changing from the defaults at run-time, but it can also be done at compile-time. 
+//!
+//! The [clap](https://crates.io/crates/clap) argument parser is used in this example, but loggerv
+//! works with any argument parser.
+
+extern crate ansi_term;
+#[macro_use] extern crate log;
+extern crate loggerv;
+extern crate clap;
+
+use clap::{Arg, App};
+use log::LogLevel;
+use loggerv::Output;
+
+fn main() {
+    // Add the following line near the beginning of the main function for an application to enable
+    // colorized output on Windows 10. 
+    //
+    // Based on documentation for the ansi_term crate, Windows 10 supports ANSI escape characters,
+    // but it must be enabled first using the `ansi_term::enable_ansi_support()` function. It is
+    // conditionally compiled and only exists for Windows builds. To avoid build errors on
+    // non-windows platforms, a cfg guard should be put in place.
+    #[cfg(windows)] ansi_term::enable_ansi_support().unwrap();
+
+    let args = App::new("app")
+       .arg(Arg::with_name("v")
+            .short("v")
+            .multiple(true)
+            .help("Sets the level of verbosity"))
+       .arg(Arg::with_name("debug")
+            .short("d")
+            .long("debug")
+            .help("Changes the output stream for INFO, DEBUG, and TRACE from stdout to stderr."))
+       .get_matches();
+
+    if args.is_present("debug") {
+        loggerv::Logger::new()
+            .output(&LogLevel::Info, Output::Stderr)
+            .output(&LogLevel::Debug, Output::Stderr)
+            .output(&LogLevel::Trace, Output::Stderr)
+    } else {
+        loggerv::Logger::new()
+    }.verbosity(args.occurrences_of("v"))
+    .init()
+    .unwrap();
+
+    error!("This is always printed to stderr");
+    warn!("This too is always printed to stderr");
+    info!("This is optionally printed to stdout or stderr based on the verbosity and the debug flag");
+    debug!("This is optionally printed to stdout or stderr based on the verbosity and the debug flag");
+    trace!("This is optionally printed to stdout or stderr based on the verbosity and the debug flag");
+}
+

--- a/examples/quick.rs
+++ b/examples/quick.rs
@@ -2,7 +2,7 @@
 //! line arguments.
 //!
 //! The default output is `module::path: message`, and the "tag", which is the text to the left of
-//! the colon, is colorized. This examples allows the user to dynamically change the output based
+//! the colon, is colorized. This example allows the user to dynamically change the output based
 //! on command line arguments.
 //!
 //! The [clap](https://crates.io/crates/clap) argument parser is used in this example, but loggerv

--- a/examples/run_time_config.rs
+++ b/examples/run_time_config.rs
@@ -2,7 +2,7 @@
 //! line arguments.
 //!
 //! The default output is `module::path: message`, and the "tag", which is the text to the left of
-//! the colon, is colorized. This examples allows the user to dynamically change the output based
+//! the colon, is colorized. This example allows the user to dynamically change the output based
 //! on command line arguments.
 //!
 //! The [clap](https://crates.io/crates/clap) argument parser is used in this example, but loggerv


### PR DESCRIPTION
I have added an example for the new `output` method API. It demonstrates how to change the output stream from `stdout` to `stderr` for a specific level. I also fixed some typos in the example documentation and made the use of level names a consistent (upper) case.

Given the recent API changes for color and output stream, a new release might be in order. I have updated the version numbers in the manifest (Cargo.toml) and README to `0.6`, along with adding a category to the manifest. I am not familiar with the release process, but would it possible to create a new release after merging these changes?