### PR TITLE
Filters and RUST_LOG support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,7 @@ path = "examples/cfg_config.rs"
 name = "output-config"
 path = "examples/output_config.rs"
 
+[[example]]
+name = "filters"
+path = "examples/filters.rs"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,11 @@ readme = "README.md"
 [dependencies]
 atty = "0.2.2"
 ansi_term = "0.10"
+env_logger = "0.5"
 log = { version = "0.4", features = ["std"] }
 
 [dev-dependencies]
-clap = "2.1.2"
+clap = "2.1"
 
 [[example]]
 name = "quick"

--- a/examples/filters.rs
+++ b/examples/filters.rs
@@ -1,0 +1,72 @@
+//! An example using the Builder pattern API to configure the logger at run-time with module
+//! filters. 
+//!
+//! The default output is `module::path: message`, and the "tag", which is the text to the left of
+//! the colon, is colorized. This example allows the user to dynamically change the output based
+//! on command line arguments.
+//!
+//! The [clap](https://crates.io/crates/clap) argument parser is used in this example, but loggerv
+//! works with any argument parser.
+
+extern crate ansi_term;
+#[macro_use] extern crate log;
+extern crate loggerv;
+extern crate clap;
+
+use clap::{Arg, App};
+
+fn main() {
+    // Add the following line near the beginning of the main function for an application to enable
+    // colorized output on Windows 10. 
+    //
+    // Based on documentation for the ansi_term crate, Windows 10 supports ANSI escape characters,
+    // but it must be enabled first using the `ansi_term::enable_ansi_support()` function. It is
+    // conditionally compiled and only exists for Windows builds. To avoid build errors on
+    // non-windows platforms, a cfg guard should be put in place.
+    #[cfg(windows)] ansi_term::enable_ansi_support().unwrap();
+
+    let args = App::new("app")
+       .arg(Arg::with_name("v")
+            .short("v")
+            .multiple(true)
+            .help("Sets the level of verbosity"))
+       .arg(Arg::with_name("debug")
+            .short("d")
+            .long("debug")
+            .help("Adds the line numbers to log statements"))
+       .arg(Arg::with_name("no-module-path")
+            .long("no-module-path")
+            .help("Disables the module path in the log statements"))
+       .arg(Arg::with_name("no-color")
+            .long("no-color")
+            .help("Disables colorized output"))
+       .arg(Arg::with_name("level")
+            .short("l")
+            .long("level")
+            .help("Adds the log level to the log statements. This will also surround the module path in square brackets."))
+       .arg(Arg::with_name("filter")
+            .short("f")
+            .long("filter")
+            .help("A comma-separated list of key-value pairs delimited with the equal sign, '=', where the key is a path to a module and the value is the level (error, warn, info, debug, or trace) of logging for the module/ley.")
+            .takes_value(true))
+       .get_matches();
+
+    if let Some(f) = args.value_of("filter") {
+        loggerv::Logger::new().filter(f)
+    } else {
+        loggerv::Logger::new()
+    }.verbosity(args.occurrences_of("v"))
+     .level(args.is_present("level"))
+     .line_numbers(args.is_present("debug"))
+     .module_path(!args.is_present("no-module-path"))
+     .colors(!args.is_present("no-color"))
+     .init()
+     .unwrap();
+
+    error!("This is always printed to stderr");
+    warn!("This too is always printed to stderr");
+    info!("This is optionally printed to stdout based on the verbosity");
+    debug!("This is optionally printed to stdout based on the verbosity");
+    trace!("This is optionally printed to stdout based on the verbosity");
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,7 @@ impl Logger {
     /// | Trace | Grey          |
     pub fn new() -> Logger {
         Logger {
-            builder: Builder::new(),
+            builder: Builder::from_env("RUST_LOG"),
             colors: DEFAULT_COLORS && atty::is(atty::Stream::Stdout) && atty::is(atty::Stream::Stderr),
             include_level: DEFAULT_INCLUDE_LEVEL,
             include_line_numbers: DEFAULT_INCLUDE_LINE_NUMBERS,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,12 +120,13 @@
 //! [log](https://crates.io/crates/log) crate for more information about its API.
 //!
 
-extern crate log;
-
 extern crate atty;
 extern crate ansi_term;
+extern crate env_logger;
+extern crate log;
 
-use log::{SetLoggerError};
+use env_logger::filter::{Builder, Filter};
+use log::SetLoggerError;
 use std::io::{self, Write};
 use ansi_term::Colour;
 
@@ -136,7 +137,6 @@ pub const DEFAULT_INCLUDE_LEVEL: bool = false;
 pub const DEFAULT_INCLUDE_LINE_NUMBERS: bool = false;
 pub const DEFAULT_INCLUDE_MODULE_PATH: bool = true;
 pub const DEFAULT_INFO_COLOR: Colour = Colour::Fixed(10); // bright green
-pub const DEFAULT_LEVEL: log::Level = log::Level::Warn;
 pub const DEFAULT_OFFSET: u64 = 1;
 pub const DEFAULT_SEPARATOR: &str = ": ";
 pub const DEFAULT_TRACE_COLOR: Colour = Colour::Fixed(8); // grey
@@ -154,13 +154,42 @@ struct Level {
     color: Colour,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+struct InnerLogger {
+    filter: Filter,
+    write: Box<Fn(&mut Write, &log::Record) -> io::Result<()> + Sync + Send>,
+    select_output: Box<Fn(&log::Level) -> Output + Sync + Send>,
+}
+
+impl InnerLogger {
+    fn filter(&self) -> log::LevelFilter {
+        self.filter.filter()
+    }
+}
+
+impl log::Log for InnerLogger {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        self.filter.enabled(metadata)
+    }
+
+    fn log(&self, record: &log::Record) {
+        if self.filter.matches(record) {
+            match (self.select_output)(&record.level()) {
+                Output::Stderr => (self.write)(&mut io::stderr(), &record).expect("Write to stderr"),
+                Output::Stdout => (self.write)(&mut io::stdout(), &record).expect("Write to stdout"),
+            };
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+#[derive(Debug)]
 pub struct Logger {
     colors: bool,
+    builder: Builder,
     include_level: bool,
     include_line_numbers: bool,
     include_module_path: bool,
-    level: log::Level,
     offset: u64,
     separator: String,
     verbosity: Option<u64>,
@@ -187,11 +216,11 @@ impl Logger {
     /// | Trace | Grey          |
     pub fn new() -> Logger {
         Logger {
+            builder: Builder::new(),
             colors: DEFAULT_COLORS && atty::is(atty::Stream::Stdout) && atty::is(atty::Stream::Stderr),
             include_level: DEFAULT_INCLUDE_LEVEL,
             include_line_numbers: DEFAULT_INCLUDE_LINE_NUMBERS,
             include_module_path: DEFAULT_INCLUDE_MODULE_PATH,
-            level: DEFAULT_LEVEL,
             offset: DEFAULT_OFFSET,
             separator: String::from(DEFAULT_SEPARATOR),
             verbosity: None,
@@ -403,7 +432,7 @@ impl Logger {
     /// }
     /// ```
     pub fn max_level(mut self, l: log::Level) -> Self {
-        self.level = l;
+        self.builder.filter(None, l.to_level_filter());
         // It is important to set the Verbosity to None here because later with the `init` method,
         // a `None` value indicates the verbosity has _not_ been set or overriden by using this
         // method (`max_level`). If the verbosity is some value, then it will be used and the use
@@ -514,7 +543,6 @@ impl Logger {
             log::Level::Info => 2,
             log::Level::Debug => 3,
             log::Level::Trace => 4,
-
         };
         self
     }
@@ -655,118 +683,95 @@ impl Logger {
             self.separator = String::new();
         }
         // The level is set based on verbosity only if the `verbosity` method has been used and
-        // _not_ overwridden a later call to the `max_level` method. If neither the `verbosity` or
-        // `max_level` method is used, then the `DEFAULT_LEVEL` is used because it is set with the
-        // `new` function. It makes more sense to calculate the level based on verbosity _after_
-        // all configuration methods have been called as opposed to during the call to the
-        // `verbosity` method. This change enables the offset feature so that the `max_level`
-        // method can be used at any time during the "building" procedure before the call to
-        // `init`. Otherwise, calling the `max_level` _after_ the `verbosity` method would have no
-        // effect and be difficult to communicate this limitation to users.
+        // _not_ overridden by a later call to the `max_level` method. If neither the `verbosity` or
+        // `max_level` method is used, then the level set by the environment is used because it is
+        // set within the `new` function when the `env_logger` filter Builder is created. It makes
+        // more sense to calculate the level based on verbosity _after_ all configuration methods
+        // have been called as opposed to during the call to the `verbosity` method. This change
+        // enables the offset feature so that the `max_level` method can be used at any time during
+        // the "building" procedure before the call to `init`. Otherwise, calling the `max_level`
+        // _after_ the `verbosity` method would have no effect and be difficult to communicate this
+        // limitation to users.
         if let Some(v) = self.verbosity {
-            self.level = match v + self.offset {
-                0 => log::Level::Error,
-                1 => log::Level::Warn,
-                2 => log::Level::Info,
-                3 => log::Level::Debug,
-                _ => log::Level::Trace,
+            match v + self.offset {
+                0 => self.builder.filter(None, log::Level::Error.to_level_filter()),
+                1 => self.builder.filter(None, log::Level::Warn.to_level_filter()),
+                2 => self.builder.filter(None, log::Level::Info.to_level_filter()),
+                3 => self.builder.filter(None, log::Level::Debug.to_level_filter()),
+                _ => self.builder.filter(None, log::Level::Trace.to_level_filter()),
             };
         }
-        log::set_max_level(self.level.to_level_filter());
-        log::set_boxed_logger(Box::new(self))
-    }
-
-    /// Gets the color to use for the log statement's tag based on level.
-    fn select_color(&self, l: &log::Level) -> Colour {
-        match *l {
-            log::Level::Error => self.error.color,
-            log::Level::Warn => self.warn.color,
-            log::Level::Info => self.info.color,
-            log::Level::Debug => self.debug.color,
-            log::Level::Trace => self.trace.color,
-        }
-    }
-
-    /// Gets the output stream to use for the level.
-    fn select_output(&self, l: &log::Level) -> Output {
-        match *l {
-            log::Level::Error => self.error.output,
-            log::Level::Warn => self.warn.output,
-            log::Level::Info => self.info.output,
-            log::Level::Debug => self.debug.output,
-            log::Level::Trace => self.trace.output,
-        }
-    }
-
-    /// Creates the tag portion of the log statement based on the configuration.
-    ///
-    /// The tag portion is the of the log statement is the text to the left of the separator, while
-    /// the text to the right of the separator is the message.
-    fn create_tag(&self, record: &log::Record) -> String {
-        let level = record.level();
-        let level_text = if self.include_level {
-            level.to_string()
-        } else {
-            String::new()
+        // Build the internal logger from the configurations. The values are "moved" into the
+        // respective closures, so cloning is needed for values that do not implement the `Copy`
+        // trait. This prevents having to duplicate all of these fields in the internal logger and
+        // avoids a bunch of `Option` type fields. Basically, the `Logger` struct becomes
+        // a builder, but to the outside world, the API and functionality is the same. See the
+        // `env_logger` crate, where the builder pattern is heavily used and was the "inspiration"
+        // for this implementation.
+        let separator = self.separator.clone();
+        let error_color = self.error.color.clone();
+        let warn_color = self.warn.color.clone();
+        let info_color = self.info.color.clone();
+        let debug_color = self.debug.color.clone();
+        let trace_color = self.trace.color.clone();
+        let error_output = self.error.output.clone();
+        let warn_output = self.warn.output.clone();
+        let info_output = self.info.output.clone();
+        let debug_output = self.debug.output.clone();
+        let trace_output = self.trace.output.clone();
+        let logger = InnerLogger {
+            filter: self.builder.build(),
+            select_output: Box::new(move |level| {
+                match *level {
+                    log::Level::Error => error_output,
+                    log::Level::Warn => warn_output,
+                    log::Level::Info => info_output,
+                    log::Level::Debug => debug_output,
+                    log::Level::Trace => trace_output,
+                }
+            }),
+            write: Box::new(move |buf, record| {
+                let level = record.level();
+                let level_text = if self.include_level {
+                    level.to_string()
+                } else {
+                    String::new()
+                };
+                let module_path_text = if self.include_module_path {
+                    let path = record.module_path().unwrap_or("unknown");
+                    if self.include_level {
+                        format!(" [{}]", path)
+                    } else {
+                        path.into()
+                    }
+                } else {
+                    String::new()
+                };
+                let line_text = if self.include_line_numbers {
+                    if let Some(l) = record.line() {
+                        format!(" (line {})", l)
+                    } else {
+                        String::new()
+                    }
+                } else {
+                    String::new()
+                };
+                let mut tag = format!("{}{}{}", level_text, module_path_text, line_text);
+                if self.colors {
+                    let color = match level {
+                        log::Level::Error => error_color,
+                        log::Level::Warn => warn_color,
+                        log::Level::Info => info_color,
+                        log::Level::Debug => debug_color,
+                        log::Level::Trace => trace_color,
+                    };
+                    tag = color.paint(tag).to_string();
+                }
+                writeln!(buf, "{}{}{}", tag, separator, record.args())
+            }),
         };
-
-        let module_path_text = if self.include_module_path {
-            let pth = record.module_path().unwrap_or("unknown");
-            if self.include_level {
-                format!(" [{}]", pth)
-            } else {
-                pth.into()
-            }
-        } else {
-            String::new()
-        };
-        let line_text = if self.include_line_numbers {
-            if let Some(l) = record.line() {
-                format!(" (line {})", l)
-            } else {
-                String::new()
-            }
-        } else {
-            String::new()
-        };
-        let mut tag = format!("{}{}{}", level_text, module_path_text, line_text);
-        if self.colors {
-            tag = self.select_color(&level).paint(tag).to_string();
-        }
-        tag
-    }
-}
-
-impl log::Log for Logger {
-    fn enabled(&self, metadata: &log::Metadata) -> bool {
-        metadata.level() <= self.level
-    }
-
-    fn log(&self, record: &log::Record) {
-        if self.enabled(record.metadata()) {
-            match self.select_output(&record.level()) {
-                Output::Stderr => {
-                    writeln!(
-                        &mut io::stderr(),
-                        "{}{}{}",
-                        self.create_tag(&record),
-                        self.separator,
-                        record.args()
-                    ).expect("Writing to stderr");
-                },
-                Output::Stdout => {
-                    println!(
-                        "{}{}{}",
-                        self.create_tag(&record),
-                        self.separator,
-                        record.args()
-                    );
-                },
-            }
-        }
-    }
-    fn flush(&self) {
-        // println! flushes by itself
+        log::set_max_level(logger.filter());
+        log::set_boxed_logger(Box::new(logger))
     }
 }
 
@@ -811,7 +816,6 @@ mod tests {
         assert_eq!(logger.include_line_numbers, DEFAULT_INCLUDE_LINE_NUMBERS);
         assert_eq!(logger.include_module_path, DEFAULT_INCLUDE_MODULE_PATH);
         assert_eq!(logger.colors, DEFAULT_COLORS);
-        assert_eq!(logger.level, DEFAULT_LEVEL);
         assert_eq!(logger.separator, String::from(DEFAULT_SEPARATOR));
         assert_eq!(logger.error.color, DEFAULT_ERROR_COLOR);
         assert_eq!(logger.warn.color, DEFAULT_WARN_COLOR);
@@ -860,7 +864,6 @@ mod tests {
     #[test]
     fn max_level_works() {
         let logger = Logger::new().max_level(log::Level::Trace);
-        assert_eq!(logger.level, log::Level::Trace);
         assert!(logger.verbosity.is_none());
     }
 
@@ -907,16 +910,6 @@ mod tests {
     fn init_works() {
         let result = Logger::new().init();
         assert!(result.is_ok());
-    }
-
-    #[test]
-    fn select_color_works() {
-        let logger = Logger::new();
-        assert_eq!(logger.select_color(&log::Level::Error), DEFAULT_ERROR_COLOR);
-        assert_eq!(logger.select_color(&log::Level::Warn), DEFAULT_WARN_COLOR);
-        assert_eq!(logger.select_color(&log::Level::Info), DEFAULT_INFO_COLOR);
-        assert_eq!(logger.select_color(&log::Level::Debug), DEFAULT_DEBUG_COLOR);
-        assert_eq!(logger.select_color(&log::Level::Trace), DEFAULT_TRACE_COLOR);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,13 @@
 //!
 //! The default configuration colorizes the "tag" portion of the log statement, where the tag is
 //! the text to the left of a separator, defaulted as the colon (`:`). The message is the
-//! portion to the right of the separator and it is _not_ ever colorized. The tag includes only the
+//! portion to the right of the separator and it is never colorized. The tag includes only the
 //! module path and the separator by default.
+//!
+//! The base and default level is inherited from the environment via the `RUST_LOG` environment variable.
+//! The log level is calculated from the base level and the verbosity. In other words, logging is
+//! first controlled by the environment and then overriden with any command line arguments or
+//! compile-time configurations.
 //!
 //! ## Example
 //!
@@ -92,11 +97,11 @@
 //!
 //! fn main() {
 //!     let args = App::new("app")
-//!                    .arg(Arg::with_name("v")
-//!                             .short("v")
-//!                             .multiple(true)
-//!                             .help("Sets the level of verbosity"))
-//!                    .get_matches();
+//!         .arg(Arg::with_name("v")
+//!             .short("v")
+//!             .multiple(true)
+//!             .help("Sets the level of verbosity"))
+//!         .get_matches();
 //!
 //!     loggerv::Logger::new()
 //!         .verbosity(args.occurrences_of("v"))
@@ -202,7 +207,7 @@ pub struct Logger {
 impl Logger {
     /// Creates a new instance of the verbosity-based logger.
     ///
-    /// The default level is WARN. Color is enabled if the parent application or library is running
+    /// The default level is ERROR. Color is enabled if the parent application or library is running
     /// from a terminal, i.e. running a tty. The default separator is the ": " string. The default
     /// output format is `module path: message`. The following default colors are used:
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,9 +532,9 @@ impl Logger {
         self
     }
 
-    /// Sets the level based on verbosity and the base level inherented from the environment.
+    /// Sets the level based on verbosity and the base level inherited from the environment.
     ///
-    /// A verbosity of zero (0) indicates the default level is inherented from the environment via
+    /// A verbosity of zero (0) indicates the default level is inherited from the environment via
     /// the `RUST_LOG` environment variable. As the verbosity is increased, the log level is increased and more
     /// log statements will be printed to `stdout`.
     ///
@@ -559,6 +559,50 @@ impl Logger {
     /// ```
     pub fn verbosity(mut self, v: u64) -> Self {
         self.verbosity = Some(v);
+        self
+    }
+
+    /// Adds filters.
+    ///
+    /// The pattern and format is identical to the
+    /// [env_logger](https://docs.rs/env_logger/0.5.3/env_logger) filter syntax and implementation.
+    /// This takes a comma-separated list of logging directives. Directives are in the form:
+    ///
+    /// ```text
+    /// path::to::module=level
+    /// ```
+    ///
+    /// # Example
+    ///
+    /// The following example will print logging statements from the `hello` module at the ERROR,
+    /// WARN, and INFO levels, while logging statements from the `goodbye` module will be printed
+    /// at the ERROR level only. The `filter` method can be used for individual directives or for
+    /// a comma-separated list, where ERROR and WARN logging statements will be printed from the
+    /// `welcome` module, TRACE, DEBUG, INFO, WARN, and ERROR logging statements will be printed
+    /// from the `thank::you` module, and ERROR, WARN, INFO, and DEBUG statements will be printed
+    /// from the `bye` module.
+    ///
+    /// ```rust
+    /// #[macro_use] extern crate log;
+    /// extern crate loggerv;
+    ///
+    /// fn main() {
+    ///     loggerv::Logger::new()
+    ///         .filter("hello=info")
+    ///         .filter("goodbye=error")
+    ///         .filter("welcome=warn,thank::you=trace,bye=debug")
+    ///         .init()
+    ///         .unwrap();
+    ///     
+    ///     error!("This is printed to stderr");
+    ///     warn!("This is printed to stderr");
+    ///     info!("This is printed to stdout");
+    ///     debug!("This is not printed to stdout");
+    ///     trace!("This is not printed to stdout");
+    /// }
+    /// ```
+    pub fn filter(mut self, directives: &str) -> Self {
+        self.builder.parse(directives);
         self
     }
 


### PR DESCRIPTION
This pull request contains changes to implement the `filter` method and support for inheriting logging configuration from the environment via the `RUST_LOG` variable, similar to the [env_logger](https://github.com/sebasmagri/env_logger/) crate as discussed in #13. In fact, the [env_logger](https://github.com/sebasmagri/env_logger/) crate already has extensive [environment and filter support](https://docs.rs/env_logger/0.5.3/env_logger/filter/index.html#using-env_logger-in-your-own-logger) that is exposed in the public API for re-use in other loggers. Thus, the functionality is re-used in this logger.

The `base_level` method has been removed because that specific functionality is now covered by using the `RUST_LOG` environment variable. However, a side effect of this implementation is that the default log level is ERROR, _not_ WARN. I cannot figure out a good way to change this default without causing odd or unexpected behavior related to verbosity and the use of the `RUST_LOG` environment variable when no filters are applied. The tradeoff is that all filter-related functionality that is implemented in the [env_logger](https://github.com/sebasmagri/env_logger/) is also implemented in this logger without duplicating efforts.

Other than the removal of the `base_level` method, the rest of the public API remains the same, but the internals have changed significantly. Based on initial tests and examples, the functionality and behavior is the same, but the source code contains numerous changes. Most notably, an internal logger is used with closures for the logging component. This avoids weirdness with the builder pattern and the filter builder from the [env_logger](https://github.com/sebasmagri/env_logger/) crate, and it avoids having a bunch of `Option` types for field members to the logger. The [env_logger](https://github.com/sebasmagri/env_logger/) crate uses a similar implementation and style.

I have also added a new example that shows using the new `filter` method with the [clap-rs](https://github.com/kbknapp/clap-rs) crate. I am not sure if the new functionality yields the desired and expected behavior with relation to the `RUST_LOG` support, so this should be viewed as a first attempt and some additional refinement might be needed.