### PR TITLE
Fix: use better defaults

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,15 +204,15 @@ impl Logger {
                 color: DEFAULT_WARN_COLOR,
             },
             info: Level {
-                output: Output::Stdout,
+                output: Output::Stderr,
                 color: DEFAULT_INFO_COLOR,
             },
             debug: Level {
-                output: Output::Stdout,
+                output: Output::Stderr,
                 color: DEFAULT_DEBUG_COLOR,
             },
             trace: Level {
-                output: Output::Stdout,
+                output: Output::Stderr,
                 color: DEFAULT_TRACE_COLOR,
             }
         }


### PR DESCRIPTION
Hi, I would like to pull this change by dnsjts as I found this to be more practical default for scripts that often produce meaningful stdout data that can be consumed by other programs. Having logging messes appear on stdout will corrupt the output by default. 
Also having all logging going to stderr makes it is trivial to redirect all logs to a log file. 
Another problem with having logs going to two different streams at the same time is potential buffering and synchronization mismatch - your logs may appear out of order or some can get buffered instead of flushed every line to terminal.