### PR TITLE
ability to force colorizing the output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,6 +304,28 @@ impl Logger {
         self
     }
 
+    /// Enables colorizing the output regardless if logger is used in a terminal or not.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// #[macro_use] extern crate log;
+    /// extern crate loggerv;
+    ///
+    /// fn main() {
+    ///     loggerv::Logger::new()
+    ///         .force_colors()
+    ///         .init()
+    ///         .unwrap();
+    ///
+    ///     error!("This is always printed with colorization");
+    /// }
+    /// ```
+    pub fn force_colors(mut self) -> Self {
+        self.colors = true;
+        self
+    }
+
     /// Disables colorizing the output.
     ///
     /// The default is to colorize the output unless `stdout` and `stderr` are redirected or piped,


### PR DESCRIPTION
When working with Jenkins or SSH colorization stops working due to standard output/error not being a terminal like output. Many terminal programs allow to force colorization of output in case one is used in environment that is not directly attached to terminal but has one attached remotely (e.g. via SSH) or has color codes handled in a special way (e.g. Jenkins plugin).
This change adds function allowing to set color to true regardless if logger is used in a terminal or not. 